### PR TITLE
Add microseconds to log format

### DIFF
--- a/utils/logging/log.go
+++ b/utils/logging/log.go
@@ -171,7 +171,7 @@ func (l *Log) format(level Level, format string, args ...interface{}) string {
 
 	return fmt.Sprintf("%s[%s]%s %s\n",
 		level,
-		time.Now().Format("01-02|15:04:05"),
+		time.Now().Format("01-02|15:04:05.000"),
 		prefix,
 		text)
 }


### PR DESCRIPTION
This PR adjusts the logger output format to include microseconds in the date/time format, eg:

```
VERBO[03-13|15:41:56.723] <SN i8KtK2KwLi1o7WaVBbEKpRLPtAEYayfoptqAFYxfQgrus1g6m> /snow/engine/avalanche/transitive.go#325: Batching 1 transactions into a new vertex
```