### PR TITLE
Place sanity checks on Username and Password length on RPC keystore.createUser method

### DIFF
--- a/api/keystore/service.go
+++ b/api/keystore/service.go
@@ -134,11 +134,11 @@ func (ks *Keystore) CreateUser(_ *http.Request, args *CreateUserArgs, reply *Cre
 	ks.lock.Lock()
 	defer ks.lock.Unlock()
 
+	ks.log.Verbo("CreateUser called with %s", args.Username[:maxUserPassLen])
+
 	if len(args.Username) > maxUserPassLen || len(args.Password) > maxUserPassLen {
 		return errUserPassMaxLength
 	}
-
-	ks.log.Verbo("CreateUser called with %s", args.Username)
 
 	if args.Username == "" {
 		return errEmptyUsername

--- a/api/keystore/service.go
+++ b/api/keystore/service.go
@@ -44,7 +44,7 @@ const (
 var (
 	errEmptyUsername     = errors.New("username can't be the empty string")
 	errUserPassMaxLength = fmt.Errorf("CreateUser call rejected due to username or password exceeding maximum length of %d chars", maxUserPassLen)
-	errWeakPassword      = errors.New("Failed to create user as the given password is to weak. Passwords must be 8 or more characters and contain a combination of UPPER and lowercase letters, numbers, and special characters")
+	errWeakPassword      = errors.New("Failed to create user as the given password is to weak. A stronger password is one of 8 or more characters containing attributes of upper and lowercase letters, numbers, and/or special characters")
 )
 
 // KeyValuePair ...

--- a/api/keystore/service.go
+++ b/api/keystore/service.go
@@ -30,7 +30,7 @@ const (
 
 var (
 	errEmptyUsername     = errors.New("username can't be the empty string")
-	errUserPassMaxLength = errors.New(fmt.Sprintf("CreateUser call rejected due to username or password exceeding maximum length of %d chars", maxUserPassLen))
+	errUserPassMaxLength = fmt.Errorf("CreateUser call rejected due to username or password exceeding maximum length of %d chars", maxUserPassLen)
 )
 
 // KeyValuePair ...

--- a/api/keystore/service.go
+++ b/api/keystore/service.go
@@ -23,8 +23,14 @@ import (
 	jsoncodec "github.com/ava-labs/gecko/utils/json"
 )
 
+const (
+	// maxUserPassLen is the maximum length of the username or password allowed
+	maxUserPassLen = 1024
+)
+
 var (
-	errEmptyUsername = errors.New("username can't be the empty string")
+	errEmptyUsername     = errors.New("username can't be the empty string")
+	errUserPassMaxLength = errors.New(fmt.Sprintf("CreateUser call rejected due to username or password exceeding maximum length of %d chars", maxUserPassLen))
 )
 
 // KeyValuePair ...
@@ -113,6 +119,10 @@ type CreateUserReply struct {
 func (ks *Keystore) CreateUser(_ *http.Request, args *CreateUserArgs, reply *CreateUserReply) error {
 	ks.lock.Lock()
 	defer ks.lock.Unlock()
+
+	if len(args.Username) > maxUserPassLen || len(args.Password) > maxUserPassLen {
+		return errUserPassMaxLength
+	}
 
 	ks.log.Verbo("CreateUser called with %s", args.Username)
 

--- a/api/keystore/service.go
+++ b/api/keystore/service.go
@@ -21,16 +21,30 @@ import (
 	"github.com/ava-labs/gecko/vms/components/codec"
 
 	jsoncodec "github.com/ava-labs/gecko/utils/json"
+	zxcvbn "github.com/nbutton23/zxcvbn-go"
 )
 
 const (
 	// maxUserPassLen is the maximum length of the username or password allowed
 	maxUserPassLen = 1024
+
+	// requiredPassScore defines the score a password must achieve to be accepted
+	// as a password with strong characteristics by the zxcvbn package
+	//
+	// The scoring mechanism defined is as follows;
+	//
+	// 0 # too guessable: risky password. (guesses < 10^3)
+	// 1 # very guessable: protection from throttled online attacks. (guesses < 10^6)
+	// 2 # somewhat guessable: protection from unthrottled online attacks. (guesses < 10^8)
+	// 3 # safely unguessable: moderate protection from offline slow-hash scenario. (guesses < 10^10)
+	// 4 # very unguessable: strong protection from offline slow-hash scenario. (guesses >= 10^10)
+	requiredPassScore = 2
 )
 
 var (
 	errEmptyUsername     = errors.New("username can't be the empty string")
 	errUserPassMaxLength = fmt.Errorf("CreateUser call rejected due to username or password exceeding maximum length of %d chars", maxUserPassLen)
+	errWeakPassword      = errors.New("Failed to create user as the given password is to weak. Passwords must be 8 or more characters and contain a combination of UPPER and lowercase letters, numbers, and special characters")
 )
 
 // KeyValuePair ...
@@ -131,6 +145,10 @@ func (ks *Keystore) CreateUser(_ *http.Request, args *CreateUserArgs, reply *Cre
 	}
 	if usr, err := ks.getUser(args.Username); err == nil || usr != nil {
 		return fmt.Errorf("user already exists: %s", args.Username)
+	}
+
+	if zxcvbn.PasswordStrength(args.Password, nil).Score < requiredPassScore {
+		return errWeakPassword
 	}
 
 	usr := &User{}

--- a/api/keystore/service.go
+++ b/api/keystore/service.go
@@ -44,7 +44,7 @@ const (
 var (
 	errEmptyUsername     = errors.New("username can't be the empty string")
 	errUserPassMaxLength = fmt.Errorf("CreateUser call rejected due to username or password exceeding maximum length of %d chars", maxUserPassLen)
-	errWeakPassword      = errors.New("Failed to create user as the given password is to weak. A stronger password is one of 8 or more characters containing attributes of upper and lowercase letters, numbers, and/or special characters")
+	errWeakPassword      = errors.New("Failed to create user as the given password is too weak. A stronger password is one of 8 or more characters containing attributes of upper and lowercase letters, numbers, and/or special characters")
 )
 
 // KeyValuePair ...

--- a/api/keystore/service.go
+++ b/api/keystore/service.go
@@ -134,7 +134,7 @@ func (ks *Keystore) CreateUser(_ *http.Request, args *CreateUserArgs, reply *Cre
 	ks.lock.Lock()
 	defer ks.lock.Unlock()
 
-	ks.log.Verbo("CreateUser called with %s", args.Username[:maxUserPassLen])
+	ks.log.Verbo("CreateUser called with %.*s", maxUserPassLen, args.Username)
 
 	if len(args.Username) > maxUserPassLen || len(args.Password) > maxUserPassLen {
 		return errUserPassMaxLength

--- a/utils/logging/log.go
+++ b/utils/logging/log.go
@@ -171,7 +171,7 @@ func (l *Log) format(level Level, format string, args ...interface{}) string {
 
 	return fmt.Sprintf("%s[%s]%s %s\n",
 		level,
-		time.Now().Format("01-02|15:04:05.000"),
+		time.Now().Format("01-02|15:04:05"),
 		prefix,
 		text)
 }


### PR DESCRIPTION
With reference to #6 this PR checks the Username and Password RPC Args length before creating a new user via the RPC keystore.createUser method.

Currently it limits the maximum length for both of these fields to 1024 characters.

Sample RPC rejection response;

```
{
  "jsonrpc": "2.0",
  "error": {
    "code": -32000,
    "message": "CreateUser call rejected due to username or password exceeding maximum length of 1024 chars",
    "data": null
  },
  "id": 1
}
```

Furthermore should the presence of nil/empty password be checked, or is it a feature to not require one?