### PR TITLE
Ignore GoLand IDE project metafiles directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,9 @@ awscpu
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
 
+# ignore GoLand metafiles directory
+.idea/
+
 *logs/
 
 .vscode*


### PR DESCRIPTION
GoLand IDE creates in a projects root a metafiles directory `.idea` which it saves project configuration information as documented here https://www.jetbrains.com/help/go/configuring-project-and-ide-settings.html

This PR adds to .gitignore the `.idea` directory so when working with git it won't pick up this directory.