### PR TITLE
Change command line arguments to use flagset to control OS exit code

### DIFF
--- a/main/params.go
+++ b/main/params.go
@@ -8,6 +8,7 @@ import (
 	"flag"
 	"fmt"
 	"net"
+	"os"
 	"path"
 	"strings"
 
@@ -44,64 +45,76 @@ func init() {
 	loggingConfig, err := logging.DefaultConfig()
 	errs.Add(err)
 
+	fs := flag.NewFlagSet("gecko", flag.ContinueOnError)
+
 	// NetworkID:
-	networkName := flag.String("network-id", genesis.LocalName, "Network ID this node will connect to")
+	networkName := fs.String("network-id", genesis.LocalName, "Network ID this node will connect to")
 
 	// Ava fees:
-	flag.Uint64Var(&Config.AvaTxFee, "ava-tx-fee", 0, "Ava transaction fee, in $nAva")
+	fs.Uint64Var(&Config.AvaTxFee, "ava-tx-fee", 0, "Ava transaction fee, in $nAva")
 
 	// Assertions:
-	flag.BoolVar(&loggingConfig.Assertions, "assertions-enabled", true, "Turn on assertion execution")
+	fs.BoolVar(&loggingConfig.Assertions, "assertions-enabled", true, "Turn on assertion execution")
 
 	// Crypto:
-	flag.BoolVar(&Config.EnableCrypto, "signature-verification-enabled", true, "Turn on signature verification")
+	fs.BoolVar(&Config.EnableCrypto, "signature-verification-enabled", true, "Turn on signature verification")
 
 	// Database:
-	db := flag.Bool("db-enabled", true, "Turn on persistent storage")
-	dbDir := flag.String("db-dir", "db", "Database directory for Ava state")
+	db := fs.Bool("db-enabled", true, "Turn on persistent storage")
+	dbDir := fs.String("db-dir", "db", "Database directory for Ava state")
 
 	// IP:
-	consensusIP := flag.String("public-ip", "", "Public IP of this node")
+	consensusIP := fs.String("public-ip", "", "Public IP of this node")
 
 	// HTTP Server:
-	httpPort := flag.Uint("http-port", 9650, "Port of the HTTP server")
-	flag.BoolVar(&Config.EnableHTTPS, "http-tls-enabled", false, "Upgrade the HTTP server to HTTPs")
-	flag.StringVar(&Config.HTTPSKeyFile, "http-tls-key-file", "", "TLS private key file for the HTTPs server")
-	flag.StringVar(&Config.HTTPSCertFile, "http-tls-cert-file", "", "TLS certificate file for the HTTPs server")
+	httpPort := fs.Uint("http-port", 9650, "Port of the HTTP server")
+	fs.BoolVar(&Config.EnableHTTPS, "http-tls-enabled", false, "Upgrade the HTTP server to HTTPs")
+	fs.StringVar(&Config.HTTPSKeyFile, "http-tls-key-file", "", "TLS private key file for the HTTPs server")
+	fs.StringVar(&Config.HTTPSCertFile, "http-tls-cert-file", "", "TLS certificate file for the HTTPs server")
 
 	// Bootstrapping:
-	bootstrapIPs := flag.String("bootstrap-ips", "", "Comma separated list of bootstrap peer ips to connect to. Example: 127.0.0.1:9630,127.0.0.1:9631")
-	bootstrapIDs := flag.String("bootstrap-ids", "", "Comma separated list of bootstrap peer ids to connect to. Example: JR4dVmy6ffUGAKCBDkyCbeZbyHQBeDsET,8CrVPQZ4VSqgL8zTdvL14G8HqAfrBr4z")
+	bootstrapIPs := fs.String("bootstrap-ips", "", "Comma separated list of bootstrap peer ips to connect to. Example: 127.0.0.1:9630,127.0.0.1:9631")
+	bootstrapIDs := fs.String("bootstrap-ids", "", "Comma separated list of bootstrap peer ids to connect to. Example: JR4dVmy6ffUGAKCBDkyCbeZbyHQBeDsET,8CrVPQZ4VSqgL8zTdvL14G8HqAfrBr4z")
 
 	// Staking:
-	consensusPort := flag.Uint("staking-port", 9651, "Port of the consensus server")
-	flag.BoolVar(&Config.EnableStaking, "staking-tls-enabled", true, "Require TLS to authenticate staking connections")
-	flag.StringVar(&Config.StakingKeyFile, "staking-tls-key-file", "", "TLS private key file for staking connections")
-	flag.StringVar(&Config.StakingCertFile, "staking-tls-cert-file", "", "TLS certificate file for staking connections")
+	consensusPort := fs.Uint("staking-port", 9651, "Port of the consensus server")
+	fs.BoolVar(&Config.EnableStaking, "staking-tls-enabled", true, "Require TLS to authenticate staking connections")
+	fs.StringVar(&Config.StakingKeyFile, "staking-tls-key-file", "", "TLS private key file for staking connections")
+	fs.StringVar(&Config.StakingCertFile, "staking-tls-cert-file", "", "TLS certificate file for staking connections")
 
 	// Logging:
-	logsDir := flag.String("log-dir", "", "Logging directory for Ava")
-	logLevel := flag.String("log-level", "info", "The log level. Should be one of {verbo, debug, info, warn, error, fatal, off}")
-	logDisplayLevel := flag.String("log-display-level", "", "The log display level. If left blank, will inherit the value of log-level. Otherwise, should be one of {verbo, debug, info, warn, error, fatal, off}")
+	logsDir := fs.String("log-dir", "", "Logging directory for Ava")
+	logLevel := fs.String("log-level", "info", "The log level. Should be one of {verbo, debug, info, warn, error, fatal, off}")
+	logDisplayLevel := fs.String("log-display-level", "", "The log display level. If left blank, will inherit the value of log-level. Otherwise, should be one of {verbo, debug, info, warn, error, fatal, off}")
 
-	flag.IntVar(&Config.ConsensusParams.K, "snow-sample-size", 20, "Number of nodes to query for each network poll")
-	flag.IntVar(&Config.ConsensusParams.Alpha, "snow-quorum-size", 18, "Alpha value to use for required number positive results")
-	flag.IntVar(&Config.ConsensusParams.BetaVirtuous, "snow-virtuous-commit-threshold", 20, "Beta value to use for virtuous transactions")
-	flag.IntVar(&Config.ConsensusParams.BetaRogue, "snow-rogue-commit-threshold", 30, "Beta value to use for rogue transactions")
-	flag.IntVar(&Config.ConsensusParams.Parents, "snow-avalanche-num-parents", 5, "Number of vertexes for reference from each new vertex")
-	flag.IntVar(&Config.ConsensusParams.BatchSize, "snow-avalanche-batch-size", 30, "Number of operations to batch in each new vertex")
+	fs.IntVar(&Config.ConsensusParams.K, "snow-sample-size", 20, "Number of nodes to query for each network poll")
+	fs.IntVar(&Config.ConsensusParams.Alpha, "snow-quorum-size", 18, "Alpha value to use for required number positive results")
+	fs.IntVar(&Config.ConsensusParams.BetaVirtuous, "snow-virtuous-commit-threshold", 20, "Beta value to use for virtuous transactions")
+	fs.IntVar(&Config.ConsensusParams.BetaRogue, "snow-rogue-commit-threshold", 30, "Beta value to use for rogue transactions")
+	fs.IntVar(&Config.ConsensusParams.Parents, "snow-avalanche-num-parents", 5, "Number of vertexes for reference from each new vertex")
+	fs.IntVar(&Config.ConsensusParams.BatchSize, "snow-avalanche-batch-size", 30, "Number of operations to batch in each new vertex")
 
 	// Enable/Disable APIs:
-	flag.BoolVar(&Config.AdminAPIEnabled, "api-admin-enabled", true, "If true, this node exposes the Admin API")
-	flag.BoolVar(&Config.KeystoreAPIEnabled, "api-keystore-enabled", true, "If true, this node exposes the Keystore API")
-	flag.BoolVar(&Config.MetricsAPIEnabled, "api-metrics-enabled", true, "If true, this node exposes the Metrics API")
-	flag.BoolVar(&Config.IPCEnabled, "api-ipcs-enabled", false, "If true, IPCs can be opened")
+	fs.BoolVar(&Config.AdminAPIEnabled, "api-admin-enabled", true, "If true, this node exposes the Admin API")
+	fs.BoolVar(&Config.KeystoreAPIEnabled, "api-keystore-enabled", true, "If true, this node exposes the Keystore API")
+	fs.BoolVar(&Config.MetricsAPIEnabled, "api-metrics-enabled", true, "If true, this node exposes the Metrics API")
+	fs.BoolVar(&Config.IPCEnabled, "api-ipcs-enabled", false, "If true, IPCs can be opened")
 
 	// Throughput Server
-	throughputPort := flag.Uint("xput-server-port", 9652, "Port of the deprecated throughput test server")
-	flag.BoolVar(&Config.ThroughputServerEnabled, "xput-server-enabled", false, "If true, throughput test server is created")
+	throughputPort := fs.Uint("xput-server-port", 9652, "Port of the deprecated throughput test server")
+	fs.BoolVar(&Config.ThroughputServerEnabled, "xput-server-enabled", false, "If true, throughput test server is created")
 
-	flag.Parse()
+	ferr := fs.Parse(os.Args[1:])
+
+	if ferr == flag.ErrHelp {
+		// display usage/help text and exit successfully
+		os.Exit(0)
+	}
+
+	if ferr != nil {
+		// other type of error occurred when parsing args
+		os.Exit(2)
+	}
 
 	networkID, err := genesis.NetworkID(*networkName)
 	errs.Add(err)

--- a/xputtest/params.go
+++ b/xputtest/params.go
@@ -6,6 +6,7 @@ package main
 import (
 	"flag"
 	"fmt"
+	"os"
 
 	stdnet "net"
 
@@ -28,35 +29,47 @@ func init() {
 	loggingConfig, err := logging.DefaultConfig()
 	errs.Add(err)
 
+	fs := flag.NewFlagSet("xputtest", flag.ContinueOnError)
+
 	// NetworkID:
-	networkName := flag.String("network-id", genesis.LocalName, "Network ID this node will connect to")
+	networkName := fs.String("network-id", genesis.LocalName, "Network ID this node will connect to")
 
 	// Ava fees:
-	flag.Uint64Var(&config.AvaTxFee, "ava-tx-fee", 0, "Ava transaction fee, in $nAva")
+	fs.Uint64Var(&config.AvaTxFee, "ava-tx-fee", 0, "Ava transaction fee, in $nAva")
 
 	// Assertions:
-	flag.BoolVar(&loggingConfig.Assertions, "assertions-enabled", true, "Turn on assertion execution")
+	fs.BoolVar(&loggingConfig.Assertions, "assertions-enabled", true, "Turn on assertion execution")
 
 	// Crypto:
-	flag.BoolVar(&config.EnableCrypto, "signature-verification-enabled", true, "Turn on signature verification")
+	fs.BoolVar(&config.EnableCrypto, "signature-verification-enabled", true, "Turn on signature verification")
 
 	// Remote Server:
-	ip := flag.String("ip", "127.0.0.1", "IP address of the remote server socket")
-	port := flag.Uint("port", 9652, "Port of the remote server socket")
+	ip := fs.String("ip", "127.0.0.1", "IP address of the remote server socket")
+	port := fs.Uint("port", 9652, "Port of the remote server socket")
 
 	// Logging:
-	logsDir := flag.String("log-dir", "", "Logging directory for Ava")
-	logLevel := flag.String("log-level", "info", "The log level. Should be one of {all, debug, info, warn, error, fatal, off}")
+	logsDir := fs.String("log-dir", "", "Logging directory for Ava")
+	logLevel := fs.String("log-level", "info", "The log level. Should be one of {all, debug, info, warn, error, fatal, off}")
 
 	// Test Variables:
-	spchain := flag.Bool("sp-chain", false, "Execute simple payment chain transactions")
-	spdag := flag.Bool("sp-dag", false, "Execute simple payment dag transactions")
-	avm := flag.Bool("avm", false, "Execute avm transactions")
-	flag.IntVar(&config.Key, "key", 0, "Index of the genesis key list to use")
-	flag.IntVar(&config.NumTxs, "num-txs", 25000, "Total number of transaction to issue")
-	flag.IntVar(&config.MaxOutstandingTxs, "max-outstanding", 1000, "Maximum number of transactions to leave outstanding")
+	spchain := fs.Bool("sp-chain", false, "Execute simple payment chain transactions")
+	spdag := fs.Bool("sp-dag", false, "Execute simple payment dag transactions")
+	avm := fs.Bool("avm", false, "Execute avm transactions")
+	fs.IntVar(&config.Key, "key", 0, "Index of the genesis key list to use")
+	fs.IntVar(&config.NumTxs, "num-txs", 25000, "Total number of transaction to issue")
+	fs.IntVar(&config.MaxOutstandingTxs, "max-outstanding", 1000, "Maximum number of transactions to leave outstanding")
 
-	flag.Parse()
+	ferr := fs.Parse(os.Args[1:])
+
+	if ferr == flag.ErrHelp {
+		// display usage/help text and exit successfully
+		os.Exit(0)
+	}
+
+	if ferr != nil {
+		// other type of error occurred when parsing args
+		os.Exit(2)
+	}
 
 	networkID, err := genesis.NetworkID(*networkName)
 	errs.Add(err)


### PR DESCRIPTION
This PR changes the gecko and xputtest command line argument parsing to use FlagSet so we can control the OS exit code.

The purpose of this change is to enable automated building of OS packages (deb, rpm) and simple integration testing which uses the following process.

 * Build go binaries
 * Package binaries into deb/rpm
 * Install built packages on OS
 * Test installed binaries are working by executing `gecko --help` or `xputtest --help`

The above process is the simplest integration test for packaging and it expects the execution of a command when passed the `--help` or `-h` arguments to output usage instructions and terminate successfully with os.Exit(0).

Currently the code does not use FlagSet so we have no control over the termination codes which default to os.Exit(2).  This of course means when passing the help arguments the usage information is displayed and exit code 2 is received which is considered an error and fails the CI build process.

Example CI process of building RPM here http://50.116.4.66/swdee/gecko/20/1/3  (This is a work in progress, currently blocked by the exit code issue)