### PR TITLE
Fixing docker container example command

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ The Gecko binary, named `ava`, is in the `build` directory.
 - Build the docker image of latest gecko branch by `scripts/build_image.sh`.
 - Check the built image by `docker image ls`, you should see some image tagged
   `gecko-xxxxxxxx`, where `xxxxxxxx` is the commit id of the Gecko source it was built from.
-- Test Gecko by `docker run -ti -p 9651:9651 gecko-xxxxxxxx /gecko/build/ava
+- Test Gecko by `docker run -ti -p 9650:9650 -p 9651:9651 gecko-xxxxxxxx /gecko/build/ava
    --public-ip=127.0.0.1 --snow-sample-size=1 --snow-quorum-size=1 --staking-tls-enabled=false`. (For a production deployment,
   you may want to extend the docker image with required credentials for
   staking and TLS.)


### PR DESCRIPTION
This is a minor edit to the README. 

The current example command for running the Docker container does not open port 9650, which means curl commands and interaction from the wallet and faucet fail. This PR adds the command to open that port.