### PR TITLE
 Add ConcurrentRepolls to make the polling throughput configurable

### DIFF
--- a/main/params.go
+++ b/main/params.go
@@ -93,6 +93,7 @@ func init() {
 	fs.IntVar(&Config.ConsensusParams.BetaRogue, "snow-rogue-commit-threshold", 30, "Beta value to use for rogue transactions")
 	fs.IntVar(&Config.ConsensusParams.Parents, "snow-avalanche-num-parents", 5, "Number of vertexes for reference from each new vertex")
 	fs.IntVar(&Config.ConsensusParams.BatchSize, "snow-avalanche-batch-size", 30, "Number of operations to batch in each new vertex")
+	fs.IntVar(&Config.ConsensusParams.ConcurrentRepolls, "snow-concurrent-repolls", 1, "Minimum number of concurrent polls for finalizing consensus")
 
 	// Enable/Disable APIs:
 	fs.BoolVar(&Config.AdminAPIEnabled, "api-admin-enabled", true, "If true, this node exposes the Admin API")

--- a/snow/consensus/avalanche/parameters_test.go
+++ b/snow/consensus/avalanche/parameters_test.go
@@ -12,10 +12,11 @@ import (
 func TestParametersValid(t *testing.T) {
 	p := Parameters{
 		Parameters: snowball.Parameters{
-			K:            1,
-			Alpha:        1,
-			BetaVirtuous: 1,
-			BetaRogue:    1,
+			K:                    1,
+			Alpha:                1,
+			BetaVirtuous:         1,
+			BetaRogue:            1,
+			ConcurrentRepolls:    1,
 		},
 		Parents:   2,
 		BatchSize: 1,
@@ -29,10 +30,11 @@ func TestParametersValid(t *testing.T) {
 func TestParametersInvalidParents(t *testing.T) {
 	p := Parameters{
 		Parameters: snowball.Parameters{
-			K:            1,
-			Alpha:        1,
-			BetaVirtuous: 1,
-			BetaRogue:    1,
+			K:                    1,
+			Alpha:                1,
+			BetaVirtuous:         1,
+			BetaRogue:            1,
+			ConcurrentRepolls:    1,
 		},
 		Parents:   1,
 		BatchSize: 1,
@@ -46,10 +48,11 @@ func TestParametersInvalidParents(t *testing.T) {
 func TestParametersInvalidBatchSize(t *testing.T) {
 	p := Parameters{
 		Parameters: snowball.Parameters{
-			K:            1,
-			Alpha:        1,
-			BetaVirtuous: 1,
-			BetaRogue:    1,
+			K:                    1,
+			Alpha:                1,
+			BetaVirtuous:         1,
+			BetaRogue:            1,
+			ConcurrentRepolls:    1,
 		},
 		Parents:   2,
 		BatchSize: 0,

--- a/snow/consensus/avalanche/topological_test.go
+++ b/snow/consensus/avalanche/topological_test.go
@@ -489,11 +489,11 @@ func TestAvalancheVirtuous(t *testing.T) {
 func TestAvalancheIsVirtuous(t *testing.T) {
 	params := Parameters{
 		Parameters: snowball.Parameters{
-			Metrics:      prometheus.NewRegistry(),
-			K:            2,
-			Alpha:        2,
-			BetaVirtuous: 1,
-			BetaRogue:    2,
+			Metrics:              prometheus.NewRegistry(),
+			K:                    2,
+			Alpha:                2,
+			BetaVirtuous:         1,
+			BetaRogue:            2,
 			ConcurrentRepolls:    1,
 		},
 		Parents:   2,
@@ -573,11 +573,11 @@ func TestAvalancheIsVirtuous(t *testing.T) {
 func TestAvalancheQuiesce(t *testing.T) {
 	params := Parameters{
 		Parameters: snowball.Parameters{
-			Metrics:      prometheus.NewRegistry(),
-			K:            1,
-			Alpha:        1,
-			BetaVirtuous: 1,
-			BetaRogue:    1,
+			Metrics:              prometheus.NewRegistry(),
+			K:                    1,
+			Alpha:                1,
+			BetaVirtuous:         1,
+			BetaRogue:            1,
 			ConcurrentRepolls:    1,
 		},
 		Parents:   2,
@@ -667,11 +667,11 @@ func TestAvalancheQuiesce(t *testing.T) {
 func TestAvalancheOrphans(t *testing.T) {
 	params := Parameters{
 		Parameters: snowball.Parameters{
-			Metrics:      prometheus.NewRegistry(),
-			K:            1,
-			Alpha:        1,
-			BetaVirtuous: math.MaxInt32,
-			BetaRogue:    math.MaxInt32,
+			Metrics:              prometheus.NewRegistry(),
+			K:                    1,
+			Alpha:                1,
+			BetaVirtuous:         math.MaxInt32,
+			BetaRogue:            math.MaxInt32,
 			ConcurrentRepolls:    1,
 		},
 		Parents:   2,

--- a/snow/consensus/avalanche/topological_test.go
+++ b/snow/consensus/avalanche/topological_test.go
@@ -27,11 +27,12 @@ func TestTopologicalTxIssued(t *testing.T) { TxIssuedTest(t, TopologicalFactory{
 func TestAvalancheVoting(t *testing.T) {
 	params := Parameters{
 		Parameters: snowball.Parameters{
-			Metrics:      prometheus.NewRegistry(),
-			K:            2,
-			Alpha:        2,
-			BetaVirtuous: 1,
-			BetaRogue:    2,
+			Metrics:              prometheus.NewRegistry(),
+			K:                    2,
+			Alpha:                2,
+			BetaVirtuous:         1,
+			BetaRogue:            2,
+			ConcurrentRepolls:    1,
 		},
 		Parents:   2,
 		BatchSize: 1,
@@ -106,11 +107,12 @@ func TestAvalancheVoting(t *testing.T) {
 func TestAvalancheTransitiveVoting(t *testing.T) {
 	params := Parameters{
 		Parameters: snowball.Parameters{
-			Metrics:      prometheus.NewRegistry(),
-			K:            2,
-			Alpha:        2,
-			BetaVirtuous: 1,
-			BetaRogue:    2,
+			Metrics:              prometheus.NewRegistry(),
+			K:                    2,
+			Alpha:                2,
+			BetaVirtuous:         1,
+			BetaRogue:            2,
+			ConcurrentRepolls:    1,
 		},
 		Parents:   2,
 		BatchSize: 1,
@@ -199,11 +201,12 @@ func TestAvalancheTransitiveVoting(t *testing.T) {
 func TestAvalancheSplitVoting(t *testing.T) {
 	params := Parameters{
 		Parameters: snowball.Parameters{
-			Metrics:      prometheus.NewRegistry(),
-			K:            2,
-			Alpha:        2,
-			BetaVirtuous: 1,
-			BetaRogue:    2,
+			Metrics:              prometheus.NewRegistry(),
+			K:                    2,
+			Alpha:                2,
+			BetaVirtuous:         1,
+			BetaRogue:            2,
+			ConcurrentRepolls:    1,
 		},
 		Parents:   2,
 		BatchSize: 1,
@@ -262,11 +265,12 @@ func TestAvalancheSplitVoting(t *testing.T) {
 func TestAvalancheTransitiveRejection(t *testing.T) {
 	params := Parameters{
 		Parameters: snowball.Parameters{
-			Metrics:      prometheus.NewRegistry(),
-			K:            2,
-			Alpha:        2,
-			BetaVirtuous: 1,
-			BetaRogue:    2,
+			Metrics:              prometheus.NewRegistry(),
+			K:                    2,
+			Alpha:                2,
+			BetaVirtuous:         1,
+			BetaRogue:            2,
+			ConcurrentRepolls:    1,
 		},
 		Parents:   2,
 		BatchSize: 1,
@@ -363,11 +367,12 @@ func TestAvalancheTransitiveRejection(t *testing.T) {
 func TestAvalancheVirtuous(t *testing.T) {
 	params := Parameters{
 		Parameters: snowball.Parameters{
-			Metrics:      prometheus.NewRegistry(),
-			K:            2,
-			Alpha:        2,
-			BetaVirtuous: 1,
-			BetaRogue:    2,
+			Metrics:              prometheus.NewRegistry(),
+			K:                    2,
+			Alpha:                2,
+			BetaVirtuous:         1,
+			BetaRogue:            2,
+			ConcurrentRepolls:    1,
 		},
 		Parents:   2,
 		BatchSize: 1,
@@ -489,6 +494,7 @@ func TestAvalancheIsVirtuous(t *testing.T) {
 			Alpha:        2,
 			BetaVirtuous: 1,
 			BetaRogue:    2,
+			ConcurrentRepolls:    1,
 		},
 		Parents:   2,
 		BatchSize: 1,
@@ -572,6 +578,7 @@ func TestAvalancheQuiesce(t *testing.T) {
 			Alpha:        1,
 			BetaVirtuous: 1,
 			BetaRogue:    1,
+			ConcurrentRepolls:    1,
 		},
 		Parents:   2,
 		BatchSize: 1,
@@ -665,6 +672,7 @@ func TestAvalancheOrphans(t *testing.T) {
 			Alpha:        1,
 			BetaVirtuous: math.MaxInt32,
 			BetaRogue:    math.MaxInt32,
+			ConcurrentRepolls:    1,
 		},
 		Parents:   2,
 		BatchSize: 1,

--- a/snow/consensus/snowball/consensus_test.go
+++ b/snow/consensus/snowball/consensus_test.go
@@ -22,7 +22,7 @@ func ParamsTest(t *testing.T, factory Factory) {
 
 	params := Parameters{
 		Metrics: prometheus.NewRegistry(),
-		K:       2, Alpha: 2, BetaVirtuous: 1, BetaRogue: 2,
+		K:       2, Alpha: 2, BetaVirtuous: 1, BetaRogue: 2, ConcurrentRepolls: 1,
 	}
 	sb.Initialize(params, Red)
 
@@ -34,5 +34,7 @@ func ParamsTest(t *testing.T, factory Factory) {
 		t.Fatalf("Wrong Beta1 parameter")
 	} else if p.BetaRogue != params.BetaRogue {
 		t.Fatalf("Wrong Beta2 parameter")
+	} else if p.ConcurrentRepolls != params.ConcurrentRepolls {
+		t.Fatalf("Wrong Repoll parameter")
 	}
 }

--- a/snow/consensus/snowball/parameters.go
+++ b/snow/consensus/snowball/parameters.go
@@ -27,8 +27,10 @@ func (p Parameters) Valid() error {
 		return fmt.Errorf("BetaVirtuous = %d: Fails the condition that: 0 < BetaVirtuous", p.BetaVirtuous)
 	case p.BetaRogue < p.BetaVirtuous:
 		return fmt.Errorf("BetaVirtuous = %d, BetaRogue = %d: Fails the condition that: BetaVirtuous <= BetaRogue", p.BetaVirtuous, p.BetaRogue)
-	case p.ConcurrentRepolls <= 0 || p.ConcurrentRepolls > p.BetaRogue:
-		return fmt.Errorf("ConcurrentRepolls = %d, BetaRogue = %d: Fails the condition that: 0 < ConcurrentRepolls <= BetaRogue", p.ConcurrentRepolls, p.BetaRogue)
+	case p.ConcurrentRepolls <= 0:
+		return fmt.Errorf("ConcurrentRepolls = %d: Fails the condition that: 0 < ConcurrentRepolls", p.ConcurrentRepolls)
+	case p.ConcurrentRepolls > p.BetaRogue:
+		return fmt.Errorf("ConcurrentRepolls = %d, BetaRogue = %d: Fails the condition that: ConcurrentRepolls <= BetaRogue", p.ConcurrentRepolls, p.BetaRogue)
 	default:
 		return nil
 	}

--- a/snow/consensus/snowball/parameters.go
+++ b/snow/consensus/snowball/parameters.go
@@ -11,9 +11,9 @@ import (
 
 // Parameters required for snowball consensus
 type Parameters struct {
-	Namespace                         string
-	Metrics                           prometheus.Registerer
-	K, Alpha, BetaVirtuous, BetaRogue int
+	Namespace                                            string
+	Metrics                                              prometheus.Registerer
+	K, Alpha, BetaVirtuous, BetaRogue, ConcurrentRepolls int
 }
 
 // Valid returns nil if the parameters describe a valid initialization.
@@ -27,6 +27,8 @@ func (p Parameters) Valid() error {
 		return fmt.Errorf("BetaVirtuous = %d: Fails the condition that: 0 < BetaVirtuous", p.BetaVirtuous)
 	case p.BetaRogue < p.BetaVirtuous:
 		return fmt.Errorf("BetaVirtuous = %d, BetaRogue = %d: Fails the condition that: BetaVirtuous <= BetaRogue", p.BetaVirtuous, p.BetaRogue)
+	case p.ConcurrentRepolls <= 0 || p.ConcurrentRepolls > p.BetaRogue:
+		return fmt.Errorf("ConcurrentRepolls = %d, BetaRogue = %d: Fails the condition that: 0 < ConcurrentRepolls <= BetaRogue", p.ConcurrentRepolls, p.BetaRogue)
 	default:
 		return nil
 	}

--- a/snow/consensus/snowball/parameters_test.go
+++ b/snow/consensus/snowball/parameters_test.go
@@ -9,10 +9,11 @@ import (
 
 func TestParametersValid(t *testing.T) {
 	p := Parameters{
-		K:            1,
-		Alpha:        1,
-		BetaVirtuous: 1,
-		BetaRogue:    1,
+		K:                    1,
+		Alpha:                1,
+		BetaVirtuous:         1,
+		BetaRogue:            1,
+		ConcurrentRepolls:    1,
 	}
 
 	if err := p.Valid(); err != nil {
@@ -22,10 +23,11 @@ func TestParametersValid(t *testing.T) {
 
 func TestParametersInvalidK(t *testing.T) {
 	p := Parameters{
-		K:            0,
-		Alpha:        1,
-		BetaVirtuous: 1,
-		BetaRogue:    1,
+		K:                    0,
+		Alpha:                1,
+		BetaVirtuous:         1,
+		BetaRogue:            1,
+		ConcurrentRepolls:    1,
 	}
 
 	if err := p.Valid(); err == nil {
@@ -35,10 +37,11 @@ func TestParametersInvalidK(t *testing.T) {
 
 func TestParametersInvalidAlpha(t *testing.T) {
 	p := Parameters{
-		K:            1,
-		Alpha:        0,
-		BetaVirtuous: 1,
-		BetaRogue:    1,
+		K:                    1,
+		Alpha:                0,
+		BetaVirtuous:         1,
+		BetaRogue:            1,
+		ConcurrentRepolls:    1,
 	}
 
 	if err := p.Valid(); err == nil {
@@ -48,10 +51,11 @@ func TestParametersInvalidAlpha(t *testing.T) {
 
 func TestParametersInvalidBetaVirtuous(t *testing.T) {
 	p := Parameters{
-		K:            1,
-		Alpha:        1,
-		BetaVirtuous: 0,
-		BetaRogue:    1,
+		K:                    1,
+		Alpha:                1,
+		BetaVirtuous:         0,
+		BetaRogue:            1,
+		ConcurrentRepolls:    1,
 	}
 
 	if err := p.Valid(); err == nil {
@@ -61,13 +65,29 @@ func TestParametersInvalidBetaVirtuous(t *testing.T) {
 
 func TestParametersInvalidBetaRogue(t *testing.T) {
 	p := Parameters{
-		K:            1,
-		Alpha:        1,
-		BetaVirtuous: 1,
-		BetaRogue:    0,
+		K:                    1,
+		Alpha:                1,
+		BetaVirtuous:         1,
+		BetaRogue:            0,
+		ConcurrentRepolls:    1,
 	}
 
 	if err := p.Valid(); err == nil {
 		t.Fatalf("Should have failed due to invalid beta rogue")
 	}
 }
+
+func TestParametersInvalidConcurrentRepolls(t *testing.T) {
+       p := Parameters{
+               K:                    1,
+               Alpha:                1,
+               BetaVirtuous:         1,
+               BetaRogue:            1,
+               ConcurrentRepolls:    2,
+       }
+
+       if err := p.Valid(); err == nil {
+               t.Fatalf("Should have failed due to invalid concurrent repolls")
+       }
+}
+

--- a/snow/engine/avalanche/config_test.go
+++ b/snow/engine/avalanche/config_test.go
@@ -26,11 +26,12 @@ func DefaultConfig() Config {
 		},
 		Params: avalanche.Parameters{
 			Parameters: snowball.Parameters{
-				Metrics:      prometheus.NewRegistry(),
-				K:            1,
-				Alpha:        1,
-				BetaVirtuous: 1,
-				BetaRogue:    2,
+				Metrics:              prometheus.NewRegistry(),
+				K:                    1,
+				Alpha:                1,
+				BetaVirtuous:         1,
+				BetaRogue:            2,
+				ConcurrentRepolls:    1,
 			},
 			Parents:   2,
 			BatchSize: 1,

--- a/snow/engine/avalanche/issuer.go
+++ b/snow/engine/avalanche/issuer.go
@@ -65,8 +65,10 @@ func (i *issuer) Update() {
 	}
 
 	i.t.RequestID++
+	polled := false
 	if numVdrs := len(vdrs); numVdrs == p.K && i.t.polls.Add(i.t.RequestID, vdrSet.Len()) {
 		i.t.Config.Sender.PushQuery(vdrSet, i.t.RequestID, vtxID, i.vtx.Bytes())
+		polled = true
 	} else if numVdrs < p.K {
 		i.t.Config.Context.Log.Error("Query for %s was dropped due to an insufficient number of validators", vtxID)
 	}
@@ -74,6 +76,10 @@ func (i *issuer) Update() {
 	i.t.vtxBlocked.Fulfill(vtxID)
 	for _, tx := range i.vtx.Txs() {
 		i.t.txBlocked.Fulfill(tx.ID())
+	}
+
+	if polled && len(i.t.polls.m) < i.t.Params.ConcurrentRepolls {
+		i.t.repoll()
 	}
 }
 

--- a/snow/engine/avalanche/transitive_test.go
+++ b/snow/engine/avalanche/transitive_test.go
@@ -340,11 +340,12 @@ func TestEngineMultipleQuery(t *testing.T) {
 
 	config.Params = avalanche.Parameters{
 		Parameters: snowball.Parameters{
-			Metrics:      prometheus.NewRegistry(),
-			K:            3,
-			Alpha:        2,
-			BetaVirtuous: 1,
-			BetaRogue:    2,
+			Metrics:           prometheus.NewRegistry(),
+			K:                 3,
+			Alpha:             2,
+			BetaVirtuous:      1,
+			BetaRogue:         2,
+			ConcurrentRepolls: 1,
 		},
 		Parents:   2,
 		BatchSize: 1,

--- a/snow/engine/avalanche/voter.go
+++ b/snow/engine/avalanche/voter.go
@@ -58,7 +58,7 @@ func (v *voter) Update() {
 
 	v.t.Config.Context.Log.Verbo("Avalanche engine can't quiesce")
 
-	if len(v.t.polls.m) == 0 {
+        if len(v.t.polls.m) < v.t.Config.Params.ConcurrentRepolls {
 		v.t.repoll()
 	}
 }

--- a/snow/engine/avalanche/voter.go
+++ b/snow/engine/avalanche/voter.go
@@ -58,7 +58,7 @@ func (v *voter) Update() {
 
 	v.t.Config.Context.Log.Verbo("Avalanche engine can't quiesce")
 
-        if len(v.t.polls.m) < v.t.Config.Params.ConcurrentRepolls {
+	if len(v.t.polls.m) < v.t.Config.Params.ConcurrentRepolls {
 		v.t.repoll()
 	}
 }

--- a/snow/engine/snowman/config_test.go
+++ b/snow/engine/snowman/config_test.go
@@ -23,10 +23,11 @@ func DefaultConfig() Config {
 		},
 		Params: snowball.Parameters{
 			Metrics:      prometheus.NewRegistry(),
-			K:            1,
-			Alpha:        1,
-			BetaVirtuous: 1,
-			BetaRogue:    2,
+			K:                    1,
+			Alpha:                1,
+			BetaVirtuous:         1,
+			BetaRogue:            2,
+			ConcurrentRepolls:    1,
 		},
 		Consensus: &snowman.Topological{},
 	}

--- a/snow/engine/snowman/transitive_test.go
+++ b/snow/engine/snowman/transitive_test.go
@@ -304,11 +304,12 @@ func TestEngineMultipleQuery(t *testing.T) {
 	config := DefaultConfig()
 
 	config.Params = snowball.Parameters{
-		Metrics:      prometheus.NewRegistry(),
-		K:            3,
-		Alpha:        2,
-		BetaVirtuous: 1,
-		BetaRogue:    2,
+		Metrics:           prometheus.NewRegistry(),
+		K:                 3,
+		Alpha:             2,
+		BetaVirtuous:      1,
+		BetaRogue:         2,
+		ConcurrentRepolls: 1,
 	}
 
 	vdr0 := validators.GenerateRandomValidator(1)
@@ -672,11 +673,12 @@ func TestVoteCanceling(t *testing.T) {
 	config := DefaultConfig()
 
 	config.Params = snowball.Parameters{
-		Metrics:      prometheus.NewRegistry(),
-		K:            3,
-		Alpha:        2,
-		BetaVirtuous: 1,
-		BetaRogue:    2,
+		Metrics:           prometheus.NewRegistry(),
+		K:                 3,
+		Alpha:             2,
+		BetaVirtuous:      1,
+		BetaRogue:         2,
+		ConcurrentRepolls: 1,
 	}
 
 	vdr0 := validators.GenerateRandomValidator(1)

--- a/snow/engine/snowman/voter.go
+++ b/snow/engine/snowman/voter.go
@@ -53,7 +53,7 @@ func (v *voter) Update() {
 
 	v.t.Config.Context.Log.Verbo("Snowman engine can't quiesce")
 
-	if len(v.t.polls.m) == 0 {
+	if len(v.t.polls.m) < v.t.Config.Params.ConcurrentRepolls {
 		v.t.repoll()
 	}
 }


### PR DESCRIPTION
This adds a ConcurrentRepolls variable to the [Snowball Parameters](https://github.com/bb-2/gecko/blob/6bde51cb7c25e88a7610d26a83dd83d4ef9464e3/snow/consensus/snowball/parameters.go#L16) and issues a `repoll()` call in both [Snowman](https://github.com/bb-2/gecko/blob/6bde51cb7c25e88a7610d26a83dd83d4ef9464e3/snow/engine/snowman/voter.go#L56) and [Avalanche](https://github.com/bb-2/gecko/blob/6bde51cb7c25e88a7610d26a83dd83d4ef9464e3/snow/engine/avalanche/voter.go#L61) when the number of pending polls is below ConcurrentRepools.

Addresses https://github.com/ava-labs/gecko/issues/25