### PR TITLE
Prevent empty vertex issuance

### DIFF
--- a/snow/engine/avalanche/issuer.go
+++ b/snow/engine/avalanche/issuer.go
@@ -85,7 +85,7 @@ func (i *issuer) Update() {
 		}
 
 	} else {
-		i.t.Config.Context.Log.Verbo("Skipping empty vertex vertex:\n%s", i.vtx)
+		i.t.Config.Context.Log.Verbo("Skipping empty vertex:\n%s", i.vtx)
 
 		for fvID, _ := range i.t.Consensus.Preferences() {
 			fvtx, err := i.t.Config.State.GetVertex(ids.NewID(fvID))

--- a/snow/engine/avalanche/state/noop_vertex.go
+++ b/snow/engine/avalanche/state/noop_vertex.go
@@ -1,0 +1,129 @@
+// (c) 2019-2020, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package state
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/ava-labs/gecko/ids"
+	"github.com/ava-labs/gecko/snow/choices"
+	"github.com/ava-labs/gecko/snow/consensus/avalanche"
+	"github.com/ava-labs/gecko/snow/consensus/snowstorm"
+	"github.com/ava-labs/gecko/utils/formatting"
+)
+
+// noopVertex acts as wrapper for stateless vertices with no txs
+type noopVertex struct {
+	serializer *Serializer
+
+	vtxID ids.ID
+	v     *noopState
+}
+
+func (vtx *noopVertex) setVertex(innerVtx *vertex) {
+	if vtx.v.vtx == nil {
+		vtx.v.vtx = innerVtx
+                vtx.setStatus(choices.Processing)
+	}
+}
+
+func (vtx *noopVertex) setStatus(status choices.Status) {
+	if vtx.v.status != status {
+		vtx.v.status = status
+	}
+}
+
+// should this retern vtx.v.ID
+func (vtx *noopVertex) ID() ids.ID { return vtx.vtxID }
+
+func (vtx *noopVertex) Accept() {
+	vtx.setStatus(choices.Accepted)
+
+	vtx.serializer.edge.Add(vtx.vtxID)
+	for _, parent := range vtx.Parents() {
+		vtx.serializer.edge.Remove(parent.ID())
+	}
+	// Should never traverse into parents of a decided vertex. Allows for the
+	// parents to be garbage collected
+	vtx.v.parents = nil
+}
+
+func (vtx *noopVertex) Reject() {
+	vtx.setStatus(choices.Rejected)
+
+	// Should never traverse into parents of a decided vertex. Allows for the
+	// parents to be garbage collected
+	vtx.v.parents = nil
+}
+
+func (vtx *noopVertex) Status() choices.Status { return vtx.v.status }
+
+func (vtx *noopVertex) Parents() []avalanche.Vertex {
+
+	if len(vtx.v.parents) != len(vtx.v.vtx.parentIDs) {
+		vtx.v.parents = make([]avalanche.Vertex, len(vtx.v.vtx.parentIDs))
+		for i, parentID := range vtx.v.vtx.parentIDs {
+			vtx.v.parents[i] = &noopVertex{
+				serializer: vtx.serializer,
+				vtxID:      parentID,
+			}
+		}
+	}
+
+	return vtx.v.parents
+}
+
+func (vtx *noopVertex) Txs() []snowstorm.Tx {
+
+	if len(vtx.v.vtx.txs) != len(vtx.v.txs) {
+		vtx.v.txs = make([]snowstorm.Tx, len(vtx.v.vtx.txs))
+		for i, tx := range vtx.v.vtx.txs {
+			vtx.v.txs[i] = tx
+		}
+	}
+
+	return vtx.v.txs
+}
+
+func (vtx *noopVertex) Bytes() []byte { return vtx.v.vtx.Bytes() }
+
+func (vtx *noopVertex) Verify() error { return vtx.v.vtx.Verify() }
+
+func (vtx *noopVertex) String() string {
+	sb := strings.Builder{}
+
+	parents := vtx.Parents()
+	txs := vtx.Txs()
+
+	sb.WriteString(fmt.Sprintf(
+		"Vertex(ID = %s, Status = %s, Number of Dependencies = %d, Number of Transactions = %d)",
+		vtx.ID(),
+		vtx.Status(),
+		len(parents),
+		len(txs),
+	))
+
+	parentFormat := fmt.Sprintf("\n    Parent[%s]: ID = %%s, Status = %%s",
+		formatting.IntFormat(len(parents)-1))
+	for i, parent := range parents {
+		sb.WriteString(fmt.Sprintf(parentFormat, i, parent.ID(), parent.Status()))
+	}
+
+	txFormat := fmt.Sprintf("\n    Transaction[%s]: ID = %%s, Status = %%s",
+		formatting.IntFormat(len(txs)-1))
+	for i, tx := range txs {
+		sb.WriteString(fmt.Sprintf(txFormat, i, tx.ID(), tx.Status()))
+	}
+
+	return sb.String()
+}
+
+type noopState struct {
+	vtx    *vertex
+	status choices.Status
+
+	parents []avalanche.Vertex
+	txs     []snowstorm.Tx
+}

--- a/snow/engine/avalanche/state/serializer.go
+++ b/snow/engine/avalanche/state/serializer.go
@@ -69,8 +69,13 @@ func (s *Serializer) ParseVertex(b []byte) (avacon.Vertex, error) {
 		return nil, err
 	}
 	if len(vtx.txs) == 0 {
-		return vtx, nil
+		nVtx := &noopVertex{
+			serializer: s,
+			vtxID:      vtx.ID(),
+		}
+		return nVtx, nil
 	}
+
 	uVtx := &uniqueVertex{
 		serializer: s,
 		vtxID:      vtx.ID(),
@@ -113,7 +118,11 @@ func (s *Serializer) BuildVertex(parentSet ids.Set, txs []snowstorm.Tx) (avacon.
 	vtx.id = ids.NewID(hashing.ComputeHash256Array(vtx.bytes))
 
 	if len(vtx.txs) == 0 {
-		return vtx, nil
+		nVtx := &noopVertex{
+			serializer: s,
+			vtxID:      vtx.ID(),
+		}
+		return nVtx, nil
 	}
 
 	uVtx := &uniqueVertex{

--- a/snow/engine/avalanche/state/serializer.go
+++ b/snow/engine/avalanche/state/serializer.go
@@ -68,6 +68,9 @@ func (s *Serializer) ParseVertex(b []byte) (avacon.Vertex, error) {
 	if err := vtx.Verify(); err != nil {
 		return nil, err
 	}
+	if len(vtx.txs) == 0 {
+		return vtx, nil
+	}
 	uVtx := &uniqueVertex{
 		serializer: s,
 		vtxID:      vtx.ID(),
@@ -108,6 +111,10 @@ func (s *Serializer) BuildVertex(parentSet ids.Set, txs []snowstorm.Tx) (avacon.
 	}
 	vtx.bytes = bytes
 	vtx.id = ids.NewID(hashing.ComputeHash256Array(vtx.bytes))
+
+	if len(vtx.txs) == 0 {
+		return vtx, nil
+	}
 
 	uVtx := &uniqueVertex{
 		serializer: s,

--- a/snow/engine/avalanche/transitive.go
+++ b/snow/engine/avalanche/transitive.go
@@ -51,7 +51,6 @@ func (t *Transitive) Initialize(config Config) {
 func (t *Transitive) getFrontier() []avalanche.Vertex {
        // Load the vertices that were last saved as the accepted frontier
        frontier := []avalanche.Vertex(nil)
-       t.Config.Context.Log.Verbo("CONFIG: %v", t.Config.State)
        for _, vtxID := range t.Config.State.Edge() {
                if vtx, err := t.Config.State.GetVertex(vtxID); err == nil {
                        frontier = append(frontier, vtx)

--- a/snow/engine/avalanche/transitive.go
+++ b/snow/engine/avalanche/transitive.go
@@ -48,16 +48,22 @@ func (t *Transitive) Initialize(config Config) {
 	t.polls.m = make(map[uint32]poll)
 }
 
+func (t *Transitive) getFrontier() []avalanche.Vertex {
+       // Load the vertices that were last saved as the accepted frontier
+       frontier := []avalanche.Vertex(nil)
+       t.Config.Context.Log.Verbo("CONFIG: %v", t.Config.State)
+       for _, vtxID := range t.Config.State.Edge() {
+               if vtx, err := t.Config.State.GetVertex(vtxID); err == nil {
+                       frontier = append(frontier, vtx)
+               } else {
+                       t.Config.Context.Log.Error("Vertex %s failed to be loaded from the frontier with %s", vtxID, err)
+               }
+       }
+       return frontier
+}
+
 func (t *Transitive) finishBootstrapping() {
-	// Load the vertices that were last saved as the accepted frontier
-	frontier := []avalanche.Vertex(nil)
-	for _, vtxID := range t.Config.State.Edge() {
-		if vtx, err := t.Config.State.GetVertex(vtxID); err == nil {
-			frontier = append(frontier, vtx)
-		} else {
-			t.Config.Context.Log.Error("Vertex %s failed to be loaded from the frontier with %s", vtxID, err)
-		}
-	}
+	frontier := getFrontier()
 	t.Consensus.Initialize(t.Config.Context, t.Params, frontier)
 	t.bootstrapped = true
 }

--- a/snow/engine/avalanche/transitive.go
+++ b/snow/engine/avalanche/transitive.go
@@ -62,7 +62,7 @@ func (t *Transitive) getFrontier() []avalanche.Vertex {
 }
 
 func (t *Transitive) finishBootstrapping() {
-	frontier := getFrontier()
+	frontier := t.getFrontier()
 	t.Consensus.Initialize(t.Config.Context, t.Params, frontier)
 	t.bootstrapped = true
 }

--- a/snow/engine/avalanche/transitive.go
+++ b/snow/engine/avalanche/transitive.go
@@ -48,21 +48,16 @@ func (t *Transitive) Initialize(config Config) {
 	t.polls.m = make(map[uint32]poll)
 }
 
-func (t *Transitive) getFrontier() []avalanche.Vertex {
-       // Load the vertices that were last saved as the accepted frontier
-       frontier := []avalanche.Vertex(nil)
-       for _, vtxID := range t.Config.State.Edge() {
-               if vtx, err := t.Config.State.GetVertex(vtxID); err == nil {
-                       frontier = append(frontier, vtx)
-               } else {
-                       t.Config.Context.Log.Error("Vertex %s failed to be loaded from the frontier with %s", vtxID, err)
-               }
-       }
-       return frontier
-}
-
 func (t *Transitive) finishBootstrapping() {
-	frontier := t.getFrontier()
+	// Load the vertices that were last saved as the accepted frontier
+	frontier := []avalanche.Vertex(nil)
+	for _, vtxID := range t.Config.State.Edge() {
+		if vtx, err := t.Config.State.GetVertex(vtxID); err == nil {
+			frontier = append(frontier, vtx)
+		} else {
+			t.Config.Context.Log.Error("Vertex %s failed to be loaded from the frontier with %s", vtxID, err)
+		}
+	}
 	t.Consensus.Initialize(t.Config.Context, t.Params, frontier)
 	t.bootstrapped = true
 }

--- a/snow/engine/avalanche/transitive_test.go
+++ b/snow/engine/avalanche/transitive_test.go
@@ -701,16 +701,16 @@ func TestEngineScheduleRepoll(t *testing.T) {
 
 	st.edge = func() []ids.ID { return []ids.ID{vts[0].ID(), vts[1].ID()} }
 	st.getVertex = func(id ids.ID) (avalanche.Vertex, error) {
-                switch {
-                case id.Equals(gVtx.ID()):
+		switch {
+		case id.Equals(gVtx.ID()):
 			return gVtx, nil
-                case id.Equals(mVtx.ID()):
-                        return mVtx, nil
+		case id.Equals(mVtx.ID()):
+			return mVtx, nil
 		case id.Equals(vtx.ID()):
 			return vtx, nil
-                }
-                t.Fatalf("Unknown vertex")
-                panic("Should have errored")
+		}
+		t.Fatalf("Unknown vertex")
+		panic("Should have errored")
 	}
 
 	st.buildVertex = func(_ ids.Set, txs []snowstorm.Tx) (avalanche.Vertex, error) {
@@ -1843,7 +1843,7 @@ func TestEngineBlockingChitResponse(t *testing.T) {
 	blockingVtx := &Vtx{
 		parents: []avalanche.Vertex{missingVtx},
 		id:      GenerateID(),
-		txs:     []snowstorm.Tx{tx2},           
+		txs:     []snowstorm.Tx{tx2},
 		height:  1,
 		status:  choices.Processing,
 		bytes:   []byte{2, 1, 2, 3},
@@ -1944,46 +1944,46 @@ func TestEngineMissingTx(t *testing.T) {
 
 	utxos := []ids.ID{GenerateID(), GenerateID(), GenerateID()}
 
-        tx0 := &TestTx{
-                TestTx: snowstorm.TestTx{Identifier: GenerateID()},
-        }
-        tx0.Ins.Add(utxos[0])
+	tx0 := &TestTx{
+		TestTx: snowstorm.TestTx{Identifier: GenerateID()},
+	}
+	tx0.Ins.Add(utxos[0])
 
-        missingVtx := &Vtx{
-                parents: vts,
-                id:      GenerateID(),
-                txs:     []snowstorm.Tx{tx0},
-                height:  1,
-                status:  choices.Unknown,
-                bytes:   []byte{0, 1, 2, 3},
-        }
+	missingVtx := &Vtx{
+		parents: vts,
+		id:      GenerateID(),
+		txs:     []snowstorm.Tx{tx0},
+		height:  1,
+		status:  choices.Unknown,
+		bytes:   []byte{0, 1, 2, 3},
+	}
 
-        tx1 := &TestTx{
-                TestTx: snowstorm.TestTx{Identifier: GenerateID()},
-        }
-        tx1.Ins.Add(utxos[1])
+	tx1 := &TestTx{
+		TestTx: snowstorm.TestTx{Identifier: GenerateID()},
+	}
+	tx1.Ins.Add(utxos[1])
 
-        issuedVtx := &Vtx{
-                parents: vts,
-                id:      GenerateID(),
-                txs:     []snowstorm.Tx{tx1},
-                height:  1,
-                status:  choices.Processing,
-                bytes:   []byte{0, 1, 2, 3},
-        }
+	issuedVtx := &Vtx{
+		parents: vts,
+		id:      GenerateID(),
+		txs:     []snowstorm.Tx{tx1},
+		height:  1,
+		status:  choices.Processing,
+		bytes:   []byte{0, 1, 2, 3},
+	}
 
-        tx2 := &TestTx{
-                TestTx: snowstorm.TestTx{Identifier: GenerateID()},
-        }
-        tx2.Ins.Add(utxos[2])
+	tx2 := &TestTx{
+		TestTx: snowstorm.TestTx{Identifier: GenerateID()},
+	}
+	tx2.Ins.Add(utxos[2])
 
-        blockingVtx := &Vtx{
-                parents: []avalanche.Vertex{missingVtx},
-                id:      GenerateID(),
-                txs:     []snowstorm.Tx{tx2},
-                height:  1,
-                status:  choices.Processing,
-                bytes:   []byte{2, 1, 2, 3},
+	blockingVtx := &Vtx{
+		parents: []avalanche.Vertex{missingVtx},
+		id:      GenerateID(),
+		txs:     []snowstorm.Tx{tx2},
+		height:  1,
+		status:  choices.Processing,
+		bytes:   []byte{2, 1, 2, 3},
 	}
 
 	st.edge = func() []ids.ID { return []ids.ID{vts[0].ID(), vts[1].ID()} }

--- a/snow/engine/avalanche/transitive_test.go
+++ b/snow/engine/avalanche/transitive_test.go
@@ -706,6 +706,8 @@ func TestEngineScheduleRepoll(t *testing.T) {
 			return gVtx, nil
                 case id.Equals(mVtx.ID()):
                         return mVtx, nil
+		case id.Equals(vtx.ID()):
+			return vtx, nil
                 }
                 t.Fatalf("Unknown vertex")
                 panic("Should have errored")


### PR DESCRIPTION
This code modifies issuer.Update to check for empty vertices and if found, rather than adding the vertex to consensus, it creates a poll for the consensus.Preferences().

@StephenButtolph Is something like this what you had in mind for https://github.com/ava-labs/gecko/issues/7?