### PR TITLE
Removed broken parent caching

### DIFF
--- a/vms/platformvm/abort_block.go
+++ b/vms/platformvm/abort_block.go
@@ -20,12 +20,13 @@ type Abort struct {
 //
 // This function also sets onAcceptDB database if the verification passes.
 func (a *Abort) Verify() error {
+	parent, ok := a.parentBlock().(*ProposalBlock)
 	// Abort is a decision, so its parent must be a proposal
-	if parent, ok := a.parentBlock().(*ProposalBlock); ok {
-		a.onAcceptDB, a.onAcceptFunc = parent.onAbort()
-	} else {
+	if !ok {
 		return errInvalidBlockType
 	}
+
+	a.onAcceptDB, a.onAcceptFunc = parent.onAbort()
 
 	a.vm.currentBlocks[a.ID().Key()] = a
 	a.parentBlock().addChild(a)

--- a/vms/platformvm/commit_block.go
+++ b/vms/platformvm/commit_block.go
@@ -21,11 +21,12 @@ type Commit struct {
 // This function also sets the onCommit databases if the verification passes.
 func (c *Commit) Verify() error {
 	// the parent of an Commit block should always be a proposal
-	if parent, ok := c.parentBlock().(*ProposalBlock); ok {
-		c.onAcceptDB, c.onAcceptFunc = parent.onCommit()
-	} else {
+	parent, ok := c.parentBlock().(*ProposalBlock)
+	if !ok {
 		return errInvalidBlockType
 	}
+
+	c.onAcceptDB, c.onAcceptFunc = parent.onCommit()
 
 	c.vm.currentBlocks[c.ID().Key()] = c
 	c.parentBlock().addChild(c)

--- a/vms/platformvm/common_blocks.go
+++ b/vms/platformvm/common_blocks.go
@@ -124,10 +124,6 @@ type CommonBlock struct {
 	*core.Block `serialize:"true"`
 	vm          *VM
 
-	// This block's parent.
-	// nil before parentBlock() is called on this block
-	parent Block
-
 	// This block's children
 	children []Block
 }
@@ -142,7 +138,6 @@ func (cb *CommonBlock) Reject() {
 // free removes this block from memory
 func (cb *CommonBlock) free() {
 	delete(cb.vm.currentBlocks, cb.ID().Key())
-	cb.parent = nil
 	cb.children = nil
 }
 
@@ -165,11 +160,6 @@ func (cb *CommonBlock) Parent() snowman.Block {
 
 // parentBlock returns this block's parent
 func (cb *CommonBlock) parentBlock() Block {
-	// Check if the block already has a reference to its parent
-	if cb.parent != nil {
-		return cb.parent
-	}
-
 	// Get the parent from database
 	parentID := cb.ParentID()
 	parent, err := cb.vm.getBlock(parentID)
@@ -177,7 +167,6 @@ func (cb *CommonBlock) parentBlock() Block {
 		cb.vm.Ctx.Log.Debug("could not get parent (ID %s) of block %s", parentID, cb.ID())
 		return nil
 	}
-	cb.parent = parent
 	return parent.(Block)
 }
 


### PR DESCRIPTION
Resolves #116 and #93.

In the platform VM, blocks are pinned to a cache when they are successfully verified, and removed from the cache when they are accepted/rejected. However, there was also caching in each block for that blocks parent. This sounds fine, however if these caches become inconsistent, then block state isn't updated correctly. This PR removes the cache from the blocks.