### PR TITLE
Clean up the acceptance of atomic blocks

### DIFF
--- a/vms/platformvm/atomic_block.go
+++ b/vms/platformvm/atomic_block.go
@@ -36,7 +36,7 @@ type AtomicTx interface {
 // AtomicBlock being accepted results in the transaction contained in the
 // block to be accepted and committed to the chain.
 type AtomicBlock struct {
-	SingleDecisionBlock `serialize:"true"`
+	CommonDecisionBlock `serialize:"true"`
 
 	Tx AtomicTx `serialize:"true"`
 
@@ -45,7 +45,7 @@ type AtomicBlock struct {
 
 // initialize this block
 func (ab *AtomicBlock) initialize(vm *VM, bytes []byte) error {
-	if err := ab.SingleDecisionBlock.initialize(vm, bytes); err != nil {
+	if err := ab.CommonDecisionBlock.initialize(vm, bytes); err != nil {
 		return err
 	}
 	return ab.Tx.initialize(vm)
@@ -123,9 +123,6 @@ func (ab *AtomicBlock) Accept() {
 		ab.onAcceptFunc()
 	}
 
-	parent := ab.parentBlock()
-	// remove this block and its parent from memory
-	parent.free()
 	ab.free()
 }
 
@@ -133,11 +130,9 @@ func (ab *AtomicBlock) Accept() {
 // decision block, has ID [parentID].
 func (vm *VM) newAtomicBlock(parentID ids.ID, tx AtomicTx) (*AtomicBlock, error) {
 	ab := &AtomicBlock{
-		SingleDecisionBlock: SingleDecisionBlock{CommonDecisionBlock: CommonDecisionBlock{
-			CommonBlock: CommonBlock{
-				Block: core.NewBlock(parentID),
-				vm:    vm,
-			},
+		CommonDecisionBlock: CommonDecisionBlock{CommonBlock: CommonBlock{
+			Block: core.NewBlock(parentID),
+			vm:    vm,
 		}},
 		Tx: tx,
 	}


### PR DESCRIPTION
Thanks @bb-2 for pointing this out. This doesn't change any behavior. However, this clarifies how the atomic block should be managed.

The `SingleDecisionBlock` struct provides a helper for blocks that can be decided and the results immediately applied to the database. However, the atomic block needs to atomically commit to multiple databases, so this helper can't be used. Which is why `AtomicBlock` implements its own `Accept` function.

Previously the `AtomicBlock` also freed it's parent block as well. This is required for `DoubleDecisionBlock`s. However, this is not needed for `SingleDecisionBlock`s or `AtomicBlock`s. Therefore, the parent is no longer freed. Freeing just un-pins the block from the cache, which is a noop if the block is already out of the cache. So, this is just a cosmetic change.