### PR TITLE
Add Rest support

### DIFF
--- a/api/keystore/service.go
+++ b/api/keystore/service.go
@@ -93,19 +93,19 @@ func (ks *Keystore) Initialize(log logging.Logger, db database.Database) {
 }
 
 var mapping jsoncodec.RPCRestMap = jsoncodec.RPCRestMap{
-	"/api/keystore/user/create": map[string]string{
+	"/keystore/user/create": map[string]string{
 		"post": "keystore.CreateUser",
 	},
-	"/api/keystore/user/delete": map[string]string{
+	"/keystore/user/delete": map[string]string{
 		"post": "keystore.DeleteUser",
 	},
-	"/api/keystore/user/list": map[string]string{
+	"/keystore/user/list": map[string]string{
 		"post": "keystore.ListUsers",
 	},
-	"/api/keystore/user/import": map[string]string{
+	"/keystore/user/import": map[string]string{
 		"post": "keystore.ImportUser",
 	},
-	"/api/keystore/user/export": map[string]string{
+	"/keystore/user/export": map[string]string{
 		"post": "keystore.ExportUser",
 	},
 }

--- a/api/keystore/service.go
+++ b/api/keystore/service.go
@@ -92,10 +92,28 @@ func (ks *Keystore) Initialize(log logging.Logger, db database.Database) {
 	ks.bcDB = prefixdb.New([]byte("bcs"), db)
 }
 
+var mapping jsoncodec.RPCRestMap = jsoncodec.RPCRestMap{
+	"/api/keystore/user/create": map[string]string{
+		"post": "keystore.CreateUser",
+	},
+	"/api/keystore/user/delete": map[string]string{
+		"post": "keystore.DeleteUser",
+	},
+	"/api/keystore/user/list": map[string]string{
+		"post": "keystore.ListUsers",
+	},
+	"/api/keystore/user/import": map[string]string{
+		"post": "keystore.ImportUser",
+	},
+	"/api/keystore/user/export": map[string]string{
+		"post": "keystore.ExportUser",
+	},
+}
+
 // CreateHandler returns a new service object that can send requests to thisAPI.
 func (ks *Keystore) CreateHandler() *common.HTTPHandler {
 	newServer := rpc.NewServer()
-	codec := jsoncodec.NewCodec()
+	codec := jsoncodec.RestCodec{Mapping: mapping}
 	newServer.RegisterCodec(codec, "application/json")
 	newServer.RegisterCodec(codec, "application/json;charset=UTF-8")
 	newServer.RegisterService(ks, "keystore")

--- a/api/router.go
+++ b/api/router.go
@@ -88,6 +88,8 @@ func (r *router) forceAddRouter(base, endpoint string, handler http.Handler) err
 	endpoints[endpoint] = handler
 	r.routes[base] = endpoints
 	r.router.Handle(url, handler)
+	url = "/api" + endpoint
+	r.router.PathPrefix(url).Handler(handler)
 
 	var err error
 	if aliases, exists := r.aliases[base]; exists {

--- a/utils/json/rest_codec.go
+++ b/utils/json/rest_codec.go
@@ -1,0 +1,71 @@
+package json
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/gorilla/rpc/v2"
+)
+
+type RPCRestMap map[string]map[string]string
+type RestCodec struct {
+	Mapping RPCRestMap
+}
+
+type RestCodecRequest struct {
+	*http.Request
+	Mapping RPCRestMap
+}
+
+func (r *RestCodecRequest) Method() (string, error) {
+	req := r.Request
+	uri := strings.ToLower(req.RequestURI)
+	if r.Mapping[uri] == nil {
+		return "", errors.New("Path not found")
+	}
+	method := strings.ToLower(req.Method)
+	if r.Mapping[uri][method] == "" {
+		return "", errors.New("Method not allowed")
+	}
+	return r.Mapping[uri][method], nil
+	// uriSections := strings.SplitN(strings.ToLower(req.RequestURI), "/", 5)
+	// method := fmt.Sprintf("%s.%s%s", uriSections[2], strings.Title(uriSections[4]), strings.Title(uriSections[3]))
+	// return method, nil
+}
+func (r *RestCodecRequest) ReadRequest(args interface{}) error {
+	buf := new(bytes.Buffer)
+	buf.ReadFrom(r.Request.Body)
+	if err := json.Unmarshal(buf.Bytes(), args); err != nil {
+		return err
+	}
+	fmt.Println(args)
+	return nil
+}
+func newEncode(w http.ResponseWriter) io.Writer {
+	return w
+}
+func (c *RestCodecRequest) WriteResponse(w http.ResponseWriter, reply interface{}) {
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	encoder := json.NewEncoder(newEncode(w))
+	err := encoder.Encode(reply)
+	fmt.Println(reply)
+	if err != nil {
+		rpc.WriteError(w, http.StatusInternalServerError, err.Error())
+	}
+}
+func (codec RestCodec) NewRequest(req *http.Request) rpc.CodecRequest {
+	fmt.Println(strings.HasPrefix(req.RequestURI, "/api"))
+	if strings.HasPrefix(req.RequestURI, "/api") {
+		r := RestCodecRequest{Request: req, Mapping: codec.Mapping}
+		return &r
+	}
+	return NewCodec().NewRequest(req)
+}
+func (c *RestCodecRequest) WriteError(w http.ResponseWriter, status int, err error) {
+	rpc.WriteError(w, http.StatusInternalServerError, err.Error())
+}


### PR DESCRIPTION
Currently for keystore users module only.

Solves https://github.com/ava-labs/gecko/issues/211. 

I thought of two methods of solving this.
First splitting the uri and creating `keystore.CreateUser` from `/api/keystore/user/create`
```
 uriSections := strings.SplitN(strings.ToLower(req.RequestURI), "/", 5)
	// method := fmt.Sprintf("%s.%s%s", uriSections[2], strings.Title(uriSections[4]), strings.Title(uriSections[3]))
```
But the problem with this is some functions have weird name and can't be defined with above approach. So, i added mapping feature. like.

```
var mapping jsoncodec.RPCRestMap = jsoncodec.RPCRestMap{
	"/keystore/user/create": map[string]string{
		"post": "keystore.CreateUser",
	},
	"/keystore/user/delete": map[string]string{
		"post": "keystore.DeleteUser",
	},
	"/keystore/user/list": map[string]string{
		"post": "keystore.ListUsers",
	},
	"/keystore/user/import": map[string]string{
		"post": "keystore.ImportUser",
	},
	"/keystore/user/export": map[string]string{
		"post": "keystore.ExportUser",
	},
}
```

In future , i will be simplifying the mapping .

Next issue is rpc only allows the post method . So, currently only post calls are there. But i added provision for other method. If i find the solution.