### PR TITLE
fix: Add a check on username in importUser

### DIFF
--- a/api/keystore/service.go
+++ b/api/keystore/service.go
@@ -266,6 +266,10 @@ func (ks *Keystore) ImportUser(r *http.Request, args *ImportUserArgs, reply *Imp
 
 	ks.log.Verbo("ImportUser called for %s", args.Username)
 
+	if args.Username == "" {
+		return errEmptyUsername
+	}
+
 	if usr, err := ks.getUser(args.Username); err == nil || usr != nil {
 		return fmt.Errorf("user already exists: %s", args.Username)
 	}

--- a/api/keystore/service_test.go
+++ b/api/keystore/service_test.go
@@ -269,6 +269,17 @@ func TestServiceExportImport(t *testing.T) {
 	{
 		reply := ImportUserReply{}
 		if err := newKS.ImportUser(nil, &ImportUserArgs{
+			Username: "",
+			Password: "strongPassword",
+			User:     exportReply.User,
+		}, &reply); err == nil {
+			t.Fatal("Should have errored due to empty username")
+		}
+	}
+
+	{
+		reply := ImportUserReply{}
+		if err := newKS.ImportUser(nil, &ImportUserArgs{
 			Username: "bob",
 			Password: strongPassword,
 			User:     exportReply.User,


### PR DESCRIPTION
Related issue : #223 

Missing 'is empty' check on 'username' parameter for the 'ImportUser' function