### PR TITLE
feat(vms)!: Prefix all platformvm addresses with P-

### DIFF
--- a/vms/platformvm/service.go
+++ b/vms/platformvm/service.go
@@ -495,7 +495,8 @@ type CreateAccountReply struct {
 }
 
 // CreateAccount creates a new account on the Platform Chain
-// The account is controlled by [args.Username]
+// The account is controlled by [args.Username], the user must already exist.
+// [args.PrivateKey] is optional, if omitted then a key will be generated.
 // The account's ID is [privKey].PublicKey().Address(), where [privKey] is a
 // private key controlled by the user.
 func (service *Service) CreateAccount(_ *http.Request, args *CreateAccountArgs, reply *CreateAccountReply) error {

--- a/vms/platformvm/service_test.go
+++ b/vms/platformvm/service_test.go
@@ -4,12 +4,64 @@
 package platformvm
 
 import (
+	"bytes"
 	"encoding/json"
 	"testing"
 	"time"
 
+	"github.com/ava-labs/gecko/api/keystore"
+	"github.com/ava-labs/gecko/utils/crypto"
 	"github.com/ava-labs/gecko/utils/formatting"
 )
+
+var (
+	// Test user username
+	testUsername string = "ScoobyUser"
+
+	// Test user password, must meet minimum complexity/length requirements
+	testPassword string = "ShaggyPassword1Zoinks!"
+
+	// Bytes docoded from CB58 "ewoqjP7PxY4yr3iLTpLisriqt94hdyDFNgchSxGGztUrTXtNN"
+	testPrivateKey []byte = []byte{
+		0x56, 0x28, 0x9e, 0x99, 0xc9, 0x4b, 0x69, 0x12,
+		0xbf, 0xc1, 0x2a, 0xdc, 0x09, 0x3c, 0x9b, 0x51,
+		0x12, 0x4f, 0x0d, 0xc5, 0x4a, 0xc7, 0xa7, 0x66,
+		0xb2, 0xbc, 0x5c, 0xcf, 0x55, 0x8d, 0x80, 0x27,
+	}
+
+	// Platform address resulting from the above private key
+	testAddress string = "P-6Y3kysjF9jnHnYkdS9yGAuoHyae2eNmeV"
+)
+
+func defaultService(t *testing.T) *Service {
+	vm := defaultVM()
+	vm.Ctx.Lock.Lock()
+	defer vm.Ctx.Lock.Unlock()
+	ks := keystore.CreateTestKeystore(t)
+	if err := ks.AddUser(testUsername, testPassword); err != nil {
+		t.Fatal(err)
+	}
+	vm.SnowmanVM.Ctx.Keystore = ks.NewBlockchainKeyStore(vm.SnowmanVM.Ctx.ChainID)
+	return &Service{vm: vm}
+}
+
+func defaultAccount(t *testing.T, service *Service) {
+	service.vm.Ctx.Lock.Lock()
+	defer service.vm.Ctx.Lock.Unlock()
+	userDB, err := service.vm.SnowmanVM.Ctx.Keystore.GetDatabase(testUsername, testPassword)
+	if err != nil {
+		t.Fatal(err)
+	}
+	user := user{db: userDB}
+	pk, err := service.vm.factory.ToPrivateKey(testPrivateKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	privKey := pk.(*crypto.PrivateKeySECP256K1R)
+	if err := user.putAccount(privKey); err != nil {
+		t.Fatal(err)
+	}
+}
 
 func TestAddDefaultSubnetValidator(t *testing.T) {
 	expectedJSONString := `{"startTime":"0","endTime":"0","id":null,"destination":"","delegationFeeRate":"0","payerNonce":"0"}`
@@ -37,20 +89,45 @@ func TestCreateBlockchainArgsParsing(t *testing.T) {
 }
 
 func TestExportKey(t *testing.T) {
-	jsonString := `{"username":"ScoobyUser","password":"ShaggyPassword1","address":"6Y3kysjF9jnHnYkdS9yGAuoHyae2eNmeV"}`
+	jsonString := `{"username":"ScoobyUser","password":"ShaggyPassword1Zoinks!","address":"P-6Y3kysjF9jnHnYkdS9yGAuoHyae2eNmeV"}`
 	args := ExportKeyArgs{}
 	err := json.Unmarshal([]byte(jsonString), &args)
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	service := defaultService(t)
+	defaultAccount(t, service)
+	service.vm.Ctx.Lock.Lock()
+	defer func() { service.vm.Shutdown(); service.vm.Ctx.Lock.Unlock() }()
+
+	reply := ExportKeyReply{}
+	if err := service.ExportKey(nil, &args, &reply); err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(testPrivateKey, reply.PrivateKey.Bytes) {
+		t.Fatalf("Expected %v, got %v", testPrivateKey, reply.PrivateKey)
+	}
 }
 
 func TestImportKey(t *testing.T) {
-	jsonString := `{"username":"ScoobyUser","password":"ShaggyPassword1","privateKey":"ewoqjP7PxY4yr3iLTpLisriqt94hdyDFNgchSxGGztUrTXtNN"}`
+	jsonString := `{"username":"ScoobyUser","password":"ShaggyPassword1Zoinks!","privateKey":"ewoqjP7PxY4yr3iLTpLisriqt94hdyDFNgchSxGGztUrTXtNN"}`
 	args := ImportKeyArgs{}
 	err := json.Unmarshal([]byte(jsonString), &args)
 	if err != nil {
 		t.Fatal(err)
+	}
+
+	service := defaultService(t)
+	service.vm.Ctx.Lock.Lock()
+	defer func() { service.vm.Shutdown(); service.vm.Ctx.Lock.Unlock() }()
+
+	reply := ImportKeyReply{}
+	if err := service.ImportKey(nil, &args, &reply); err != nil {
+		t.Fatal(err)
+	}
+	if testAddress != reply.Address {
+		t.Fatalf("Expected %q, got %q", testAddress, reply.Address)
 	}
 }
 

--- a/vms/platformvm/vm.go
+++ b/vms/platformvm/vm.go
@@ -6,6 +6,7 @@ package platformvm
 import (
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	stdmath "math"
@@ -102,7 +103,12 @@ var (
 	errMissingBlock             = errors.New("missing block")
 	errInvalidLastAcceptedBlock = errors.New("last accepted block must be a decision block")
 	errInvalidAddress           = errors.New("invalid address")
+	errInvalidAddressSeperator  = errors.New("invalid address seperator")
+	errInvalidAddressPrefix     = errors.New("invalid address prefix")
+	errInvalidAddressSuffix     = errors.New("invalid address suffix")
 	errEmptyAddress             = errors.New("empty address")
+	errEmptyAddressPrefix       = errors.New("empty address prefix")
+	errEmptyAddressSuffix       = errors.New("empty address suffix")
 )
 
 // Codec does serialization and deserialization
@@ -872,18 +878,45 @@ func (vm *VM) GetAtomicUTXOs(addrs ids.Set) ([]*ava.UTXO, error) {
 	return utxos, nil
 }
 
-// ParseAddress ...
+func splitAddress(addrStr string) (string, string, error) {
+	if count := strings.Count(addrStr, addressSep); count != 1 {
+		return "", "", errInvalidAddressSeperator
+	}
+	addrParts := strings.SplitN(addrStr, addressSep, 2)
+	prefix := addrParts[0]
+	if prefix == "" {
+		return "", "", errEmptyAddressPrefix
+	}
+	suffix := addrParts[1]
+	if suffix == "" {
+		return "", "", errEmptyAddressSuffix
+	}
+	return prefix, suffix, nil
+}
+
+// ParseAddress returns a decoded Platform Chain address.
+// addrStr is an encoded address, of the form "P-<CB58 encoded bytes>".
 func (vm *VM) ParseAddress(addrStr string) (ids.ShortID, error) {
-	cb58 := formatting.CB58{}
-	err := cb58.FromString(addrStr)
+	if addrStr == "" {
+		return ids.ShortID{}, errEmptyAddress
+	}
+	prefix, suffix, err := splitAddress(addrStr)
 	if err != nil {
 		return ids.ShortID{}, err
+	}
+	if prefix != platformAlias {
+		return ids.ShortID{}, errInvalidAddressPrefix
+	}
+	cb58 := formatting.CB58{}
+	err = cb58.FromString(suffix)
+	if err != nil {
+		return ids.ShortID{}, fmt.Errorf("%w: %v", errInvalidAddress, err)
 	}
 	return ids.ToShortID(cb58.Bytes)
 }
 
-// FormatAddress ...
-// Assumes addrID is not empty
+// FormatAddress returns an encoded Platform Chain address, of the form
+// "P-<CB58 encoded bytes>".
 func (vm *VM) FormatAddress(addrID ids.ShortID) string {
-	return addrID.String()
+	return fmt.Sprintf("%s%s%s", platformAlias, addressSep, addrID.String())
 }

--- a/vms/platformvm/vm_test.go
+++ b/vms/platformvm/vm_test.go
@@ -1798,3 +1798,52 @@ func TestUnverifiedParent(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestParseAddress(t *testing.T) {
+	vm := &VM{}
+	if _, err := vm.ParseAddress("P-Bg6e45gxCUTLXcfUuoy3go2U6V3bRZ5jH"); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestParseAddressInvalid(t *testing.T) {
+	vm := &VM{}
+	tests := []struct {
+		in   string
+		want error
+	}{
+		{"", errEmptyAddress},
+		{"+", errInvalidAddressSeperator},
+		{"P", errInvalidAddressSeperator},
+		{"-", errEmptyAddressPrefix},
+		{"P-", errEmptyAddressSuffix},
+		{"X-Bg6e45gxCUTLXcfUuoy3go2U6V3bRZ5jH", errInvalidAddressPrefix},
+		{"P-Bg6e45gxCUTLXcfUuoy", errInvalidAddress}, //truncated
+	}
+	for _, tt := range tests {
+		t.Run(tt.in, func(t *testing.T) {
+			_, err := vm.ParseAddress(tt.in)
+			if !errors.Is(err, tt.want) {
+				t.Errorf("want %q, got %q", tt.want, err)
+			}
+		})
+	}
+}
+
+func TestFormatAddress(t *testing.T) {
+	vm := &VM{}
+	tests := []struct {
+		label string
+		in    ids.ShortID
+		want  string
+	}{
+		{"keys[0]", keys[0].PublicKey().Address(), "P-Q4MzFZZDPHRPAHFeDs3NiyyaZDvxHKivf"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.label, func(t *testing.T) {
+			if addrStr := vm.FormatAddress(tt.in); addrStr != tt.want {
+				t.Errorf("want %q, got %q", tt.want, addrStr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
BREAKING CHANGE: This is a backward incompatible change.

Gecko will now return platformvm addresses with a P- prefix in all RPC calls, and logs. Any platformvm address lacking a P- prefix will not be accepted in RPC calls as invalid.

A platformvm address that was 6Y3kysjF9jnHnYkdS9yGAuoHyae2eNmeV now becomes P-6Y3kysjF9jnHnYkdS9yGAuoHyae2eNmeV.

As an experiment this commit message is formatted according to https://www.conventionalcommits.org/en/v1.0.0-beta.4/

Fixes #161 