### PR TITLE
Configure log highlighting, add flag "-log-display-highlight"

### DIFF
--- a/main/params.go
+++ b/main/params.go
@@ -217,6 +217,7 @@ func init() {
 	logsDir := fs.String("log-dir", "", "Logging directory for Ava")
 	logLevel := fs.String("log-level", "info", "The log level. Should be one of {verbo, debug, info, warn, error, fatal, off}")
 	logDisplayLevel := fs.String("log-display-level", "", "The log display level. If left blank, will inherit the value of log-level. Otherwise, should be one of {verbo, debug, info, warn, error, fatal, off}")
+	logDisplayHighlight := fs.String("log-display-highlight", "auto", "Whether to color/highlight display logs. Default highlights when the output is a terminal. Otherwise, should be one of {auto, plain, colors}")
 
 	fs.IntVar(&Config.ConsensusParams.K, "snow-sample-size", 5, "Number of nodes to query for each network poll")
 	fs.IntVar(&Config.ConsensusParams.Alpha, "snow-quorum-size", 4, "Alpha value to use for required number positive results")
@@ -426,6 +427,12 @@ func init() {
 		return
 	}
 	loggingConfig.DisplayLevel = displayLevel
+
+	displayHighlight, err := logging.ToHighlight(*logDisplayHighlight, os.Stdout.Fd())
+	if errs.Add(err); err != nil {
+		return
+	}
+	loggingConfig.DisplayHighlight = displayHighlight
 
 	Config.LoggingConfig = loggingConfig
 

--- a/utils/logging/config.go
+++ b/utils/logging/config.go
@@ -18,6 +18,7 @@ type Config struct {
 	FileSize, RotationSize, FlushSize                                                               int
 	DisableLogging, DisableDisplaying, DisableContextualDisplaying, DisableFlushOnWrite, Assertions bool
 	LogLevel, DisplayLevel                                                                          Level
+	DisplayHighlight                                                                                Highlight
 	Directory, MsgPrefix                                                                            string
 }
 
@@ -30,6 +31,7 @@ func DefaultConfig() (Config, error) {
 		RotationSize:     7,
 		FlushSize:        1,
 		DisplayLevel:     Info,
+		DisplayHighlight: Plain,
 		LogLevel:         Debug,
 		Directory:        dir,
 	}, err

--- a/utils/logging/highlight.go
+++ b/utils/logging/highlight.go
@@ -1,0 +1,38 @@
+// (c) 2020, Alex Willmer, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package logging
+
+import (
+	"fmt"
+	"strings"
+
+	"golang.org/x/crypto/ssh/terminal"
+)
+
+// Highlighting mode to apply to displayed logs
+type Highlight int
+
+// Highlighting modes available
+const (
+	Plain Highlight = iota
+	Colors
+)
+
+// Choose a highlighting mode
+func ToHighlight(h string, fd uintptr) (Highlight, error) {
+	switch strings.ToUpper(h) {
+	case "PLAIN":
+		return Plain, nil
+	case "COLORS":
+		return Colors, nil
+	case "AUTO":
+		if !terminal.IsTerminal(int(fd)) {
+			return Plain, nil
+		} else {
+			return Colors, nil
+		}
+	default:
+		return Plain, fmt.Errorf("unknown highlight mode: %s", h)
+	}
+}

--- a/utils/logging/log.go
+++ b/utils/logging/log.go
@@ -148,6 +148,8 @@ func (l *Log) log(level Level, format string, args ...interface{}) {
 	if shouldDisplay {
 		if l.config.DisableContextualDisplaying {
 			fmt.Println(fmt.Sprintf(format, args...))
+		} else if l.config.DisplayHighlight == Plain {
+			fmt.Print(output)
 		} else {
 			fmt.Print(level.Color().Wrap(output))
 		}


### PR DESCRIPTION
With this change highlighting of logs displayed on stdout can be
configured. The default is to highlight using color, if stdout is a
terminal. This can be overridden with the -log-display-highlight flag -
to force color output, or force plain output.

An Enum is used, rather than a boolean to allow other highlighting
schemes (e.g. underline).

Fixes #169