### PR TITLE
Fix health check

### DIFF
--- a/api/health/service.go
+++ b/api/health/service.go
@@ -17,7 +17,10 @@ import (
 )
 
 // defaultCheckOpts is a Check whose properties represent a default Check
-var defaultCheckOpts = check{executionPeriod: time.Minute}
+var defaultCheckOpts = check{
+	executionPeriod: time.Minute,
+	initialDelay:    10 * time.Second,
+}
 
 // Health observes a set of vital signs and makes them available through an HTTP
 // API.

--- a/chains/manager.go
+++ b/chains/manager.go
@@ -563,8 +563,7 @@ func (m *manager) IsBootstrapped(id ids.ID) bool {
 	if !exists {
 		return false
 	}
-	chain.Context().Lock.Lock()
-	defer chain.Context().Lock.Unlock()
+
 	return chain.Engine().IsBootstrapped()
 }
 

--- a/snow/engine/snowman/transitive.go
+++ b/snow/engine/snowman/transitive.go
@@ -4,6 +4,7 @@
 package snowman
 
 import (
+	"sync/atomic"
 	"time"
 
 	"github.com/ava-labs/gecko/ids"
@@ -46,7 +47,8 @@ type Transitive struct {
 	blocked events.Blocker
 
 	// mark for if the engine has been bootstrapped or not
-	bootstrapped bool
+	bootstrapped       bool
+	atomicBootstrapped *uint32
 
 	// errs tracks if an error has occurred in a callback
 	errs wrappers.Errs
@@ -64,6 +66,7 @@ func (t *Transitive) Initialize(config Config) error {
 	)
 
 	t.onFinished = t.finishBootstrapping
+	t.atomicBootstrapped = new(uint32)
 
 	factory := poll.NewEarlyTermNoTraversalFactory(int(config.Params.Alpha))
 	t.polls = poll.NewSet(factory,
@@ -80,6 +83,7 @@ func (t *Transitive) Initialize(config Config) error {
 func (t *Transitive) finishBootstrapping() error {
 	// set the bootstrapped mark to switch consensus modes
 	t.bootstrapped = true
+	atomic.StoreUint32(t.atomicBootstrapped, 1)
 
 	// initialize consensus to the last accepted blockID
 	tailID := t.Config.VM.LastAccepted()
@@ -650,5 +654,5 @@ func (t *Transitive) deliver(blk snowman.Block) error {
 
 // IsBootstrapped returns true iff this chain is done bootstrapping
 func (t *Transitive) IsBootstrapped() bool {
-	return t.bootstrapped
+	return atomic.LoadUint32(t.atomicBootstrapped) > 0
 }


### PR DESCRIPTION
Use channel to signal chain manager when chains have finished bootstrapping
Add default 10 second initial delay to health checks