### PR TITLE
ansible: Don't install C build dependencies

### DIFF
--- a/scripts/ansible/roles/ava-base/tasks/main.yml
+++ b/scripts/ansible/roles/ava-base/tasks/main.yml
@@ -2,13 +2,6 @@
   become: true
   apt:
     name:
-      # Build
-      - cmake
-      - curl
-      - g++
-      - libssl-dev
-      - libuv1-dev
-      - make
       # Staking key management
       - openssl
       - python3-cryptography


### PR DESCRIPTION
They are no longer needed.